### PR TITLE
adds amd64 architecture to case statement to support ami-ce7dbaa6 (Ubuntu 12.04)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,9 +27,9 @@ class sumo::params {
   $sources_template   = 'sumo/sumo.json.erb'
 
   case $::architecture {
-    'x86_64': {
+    'x86_64','amd64': {
       $download_url = 'https://collectors.sumologic.com/rest/download/linux/64'
-    }
+    }    
     'x86': {
       $download_url = 'https://collectors.sumologic.com/rest/download/linux/32'
     }


### PR DESCRIPTION
Hi Mike - this change will get things working on ubuntu 12.04.  Nice module!  --db