### PR TITLE
adds amd64 architecture to case statement to support ami-ce7dbaa6 (12.04)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class sumo::params {
   $sources_template   = 'sumo/sumo.json.erb'
 
   case $::architecture {
-    'x86_64': {
+    'x86_64','amd64': {
       $download_url = 'https://collectors.sumologic.com/rest/download/linux/64'
     }
     'x86': {


### PR DESCRIPTION
Hi Mike - I amended the commit (by removing the end of line character).  --db
